### PR TITLE
Uses ENV for Debian noninteractive

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ ENV PULSE_SERVER unix:/run/user/1001/pulse/native
 #########################START  INSTALLATIONS##########################
 
 # We don't want any interaction from package installation during the docker image building.
-ARG DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND noninteractive
 
 
 # We want the 32 bits version of wine allowing winetricks.


### PR DESCRIPTION
Use `ENV` instead of `ARG` for `DEBIAN_FRONTEND=noninteractive`. Had to adjust this one locally while building to avoid interaction from the `keyboard-configuration` package.